### PR TITLE
Add requirements file to also include py3 dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+DateTime==4.1.1
+python-dateutil==2.5.3
+pytz==2016.4
+six==1.10.0
+tornado==4.3
+zope.interface==4.1.3


### PR DESCRIPTION
py3 dateutil is also required to get your code up and running. I've created a base requirements file that can be used within virtualenv via `pip install -r requirements.txt`
